### PR TITLE
fix powershell issue https://github.com/chocolatey/choco/issues/659

### DIFF
--- a/nuget/chocolatey.nuspec
+++ b/nuget/chocolatey.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>chocolatey</id>
     <title>Chocolatey</title>
-    <version>0.9.8.23-nuget28hf4</version>
+    <version>0.9.8.23-nuget28hf4-ps</version>
     <authors>Rob Reynolds, The Chocolatey Team</authors>
     <owners>Rob Reynolds</owners>
     <summary>Chocolatey is your machine level NuGet repository. Think apt-get for Windows (executables/application packages), not library packages.</summary>

--- a/src/chocolatey.ps1
+++ b/src/chocolatey.ps1
@@ -15,7 +15,7 @@
   [string] $name,
   [switch] $ignoreDependencies = $false,
   [alias("x86")][switch] $forceX86 = $false,
-  [alias("params")][alias("parameters")][alias("pkgParams")][string]$packageParameters = '',
+  [alias("params","parameters","pkgParams")][string]$packageParameters = '',
   [parameter(Position=1, ValueFromRemainingArguments=$true)]
   [string[]]$packageNames=@('')
 )
@@ -43,7 +43,7 @@ $currentThread.CurrentCulture = $culture;
 $currentThread.CurrentUICulture = $culture;
 
 #Let's get Chocolatey!
-$chocVer = '0.9.8.23-nuget28hf4'
+$chocVer = '0.9.8.23-nuget28hf4-ps'
 $nugetChocolateyPath = (Split-Path -parent $MyInvocation.MyCommand.Definition)
 $nugetPath = (Split-Path -Parent $nugetChocolateyPath)
 $nugetExePath = Join-Path $nuGetPath 'bin'


### PR DESCRIPTION
a fix in chocolatey/choco#659 : error when installing chocolatey (Collection is read-only) 
 Basically you get an error when running chocolatey.ps1 similar to the one below.

Collection is read-only.
 At line:1 char:126
•... ulture = '';& 'C:\Chocolatey\chocolateyinstall\chocolatey.ps1' instal ...
• ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ◦CategoryInfo : OperationStopped: (:) [], NotSupportedException
◦FullyQualifiedErrorId : System.NotSupportedException

Even Get-Help will throw it. Quick fix is to change like explained in the bug item:

From:
 [alias("params")][alias(“parameters”)][alias(“pkgParams")]

To:
 [alias("params'',"parameters","pkgParams")]
